### PR TITLE
Add installation step for PlantUML and Graphviz in deployment workflow

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -18,6 +18,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Install PlantUML
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y plantuml graphviz
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 


### PR DESCRIPTION
This pull request adds a step to the documentation deployment workflow to ensure PlantUML and Graphviz are installed before building the docs. This will allow diagrams defined in PlantUML to be properly rendered during documentation builds.

- Documentation build improvements:
  * [`.github/workflows/deploy_docs.yml`](diffhunk://#diff-03a7a8b3c4769e5bf1edd4a2edfa35190b649a71acf721c44d6b985e5a916719R21-R25): Added a step to install PlantUML and Graphviz prior to building documentation, enabling support for rendering PlantUML diagrams.