### PR TITLE
Fix/#53 check field beforehand tclean

### DIFF
--- a/almaqso/_templates/_tclean_cube.py
+++ b/almaqso/_templates/_tclean_cube.py
@@ -10,6 +10,12 @@ cell, imsize, _ = aU.pickCellSize(vis, imsize=True, cellstring=True)
 fields = aU.getFields(vis)
 
 for field in fields:
+    ms.open(vis)
+    ms.reset()
+    ret_select = ms.msselect({{'field': str(field)}})
+    ms.close()
+    if not ret_select:
+        continue
     msmd.open(vis)
     spws = msmd.spwsforfield(field)
     msmd.close()
@@ -17,9 +23,8 @@ for field in fields:
         ms.open(vis)
         ms.reset()
         ret_select = ms.msselect({{'field': str(field), 'spw': str(spw)}})
-        num_row = ms.nrow()
         ms.close()
-        if (not ret_select) or (num_row == 0):
+        if not ret_select:
             continue
         tclean(
             vis=vis,

--- a/almaqso/_templates/_tclean_mfs.py
+++ b/almaqso/_templates/_tclean_mfs.py
@@ -10,6 +10,11 @@ cell, imsize, _ = aU.pickCellSize(vis, imsize=True, cellstring=True)
 fields = aU.getFields(vis)
 
 for field in fields:
+    ms.open(vis)
+    ret_select = ms.msselect({{'field': str(field)}})
+    ms.close()
+    if not ret_select:
+        continue
     tclean(
         vis=vis,
         imagename=f"{{dir}}/{{field}}_mfs",

--- a/almaqso/_templates/_tclean_mfs_spw.py
+++ b/almaqso/_templates/_tclean_mfs_spw.py
@@ -10,6 +10,12 @@ cell, imsize, _ = aU.pickCellSize(vis, imsize=True, cellstring=True)
 fields = aU.getFields(vis)
 
 for field in fields:
+    ms.open(vis)
+    ms.reset()
+    ret_select = ms.msselect({{'field': str(field)}})
+    ms.close()
+    if not ret_select:
+        continue
     msmd.open(vis)
     spws = msmd.spwsforfield(field)
     msmd.close()
@@ -17,9 +23,8 @@ for field in fields:
         ms.open(vis)
         ms.reset()
         ret_select = ms.msselect({{'field': str(field), 'spw': str(spw)}})
-        num_row = ms.nrow()
         ms.close()
-        if (not ret_select) or (num_row == 0):
+        if not ret_select:
             continue
         tclean(
             vis=vis,


### PR DESCRIPTION
- close #53 

## 概要

#53 「イメージングでのエラー "Data selection ended with 0 rows"」を直した。
イメージング（tclean）において、データが存在しない（0 rows な）`field` を選択して SEVERE エラーが発出されていた。
事前チェックを挟むことでこれを解消した。

## コードの変更

**`almaqso/_templates/_tclean_mfs.py`**

- `field` ごとのイメージングにおいて、最初にその `field` にデータが存在するか確認するようにした

**`almaqso/_templates/_tclean_mfs_spw.py` & `almaqso/_templates/_tclean_cube.py`**

- 同上の変更を、SPW ごとのループの前に移動した。これは、`msmd.spwsforfield(field)` がデータの存在しない `field` でエラーを発出していたからである。

## テスト結果

#53 でエラーとなっていた `uid___A002_X1211273_X8ead` に対してデバッグを行った。
修正により、SEVERE エラーが解消した。