### PR TITLE
Fix PyPI upload by switching to setuptools_scm dynamic versioning

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,14 +29,6 @@ jobs:
           python -m pip install --upgrade setuptools wheel twine setuptools_scm build
           python -m build
 
-      - name: Debug setuptools_scm
-        run: |
-          git fetch --tags
-          python - <<'EOF'
-          import setuptools_scm
-          print("setuptools_scm.get_version():", setuptools_scm.get_version(root='.', fallback_version='none'))
-          EOF
-
       - name: Publish to PyPI
         env:
           TWINE_USERNAME: __token__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "almaqso"
-version = "1.6.1"
+dynamic = ["version"]
 description = "Automation for downloading and processing ALMA calibration target observations."
 readme = "README.md"
 requires-python = ">=3.13"
@@ -26,6 +26,8 @@ dependencies = [
     "tdqm>=0.0.1",
     "tenacity>=9.1.2",
 ]
+
+[tool.setuptools_scm]
 
 [tool.pytest.ini_options]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "almaqso"
-version = "1.6.0"
+version = "1.6.1"
 description = "Automation for downloading and processing ALMA calibration target observations."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,6 @@ wheels = [
 
 [[package]]
 name = "almaqso"
-version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "astroquery" },

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ wheels = [
 
 [[package]]
 name = "almaqso"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "astroquery" },


### PR DESCRIPTION
## Summary

- `pyproject.toml` の静的 `version` を削除し、`dynamic = ["version"]` + `[tool.setuptools_scm]` に変更
- git タグからバージョンを自動生成するようにしたことで、手動でのバージョン更新漏れを防ぐ
- ワークフローの不要になった Debug ステップを削除

## Test plan

- [ ] v1.6.1 リリースを再実行し、PyPI への upload が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)